### PR TITLE
영수증 리워드 기업 조회 시 조건 추가

### DIFF
--- a/Application/Reward/src/main/java/com/example/Reward/Receipt/Service/ReceiptService.java
+++ b/Application/Reward/src/main/java/com/example/Reward/Receipt/Service/ReceiptService.java
@@ -184,7 +184,7 @@ public class ReceiptService {
         if(storeName.equals("STARBUCKS")) return "이마트";
         for(String name : enterprises) {
             String detected = getLongestCommonSubstring.getlongestCommonSubstring(name, storeName);
-            if(detected.length()>longest.length()) {
+            if(detected.length()>longest.length() && detected.length()>name.length()/2) {
                 longest = detected;
             }
         }


### PR DESCRIPTION
### PR 타입
- [] 기능 추가
- [x] 기능 수정
- [] 기능 삭제
- [] 버그 수정
- [] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feat/reward/receipt/wordlength -> develop

### 변경 사항
글자 수 절반 이상 겹치는 기업만 리워드 받을 수 있도록 수정했습니다.

### 테스트 결과
스타벅스 조건 없을 때 기존에 CJ CGV 뜨는 것 수정
![image](https://github.com/user-attachments/assets/a1f30059-1dc4-42cc-bdea-c4829070982a)
